### PR TITLE
fix(ecr-build): ECR lifecycle policies

### DIFF
--- a/.github/workflows/ecr-build.yaml
+++ b/.github/workflows/ecr-build.yaml
@@ -112,26 +112,36 @@ jobs:
           {
             "rules": [
               {
-                "rulePriority": 1,
-                "description": "Keep 5 versions of important tags",
+                "rulePriority": 10,
+                "description": "Keep 25 versions of main tag",
                 "selection": {
                   "tagStatus": "tagged",
-                  "tagPrefixList": [
-                    "main",
-                    "master"
-                  ],
+                  "tagPrefixList": ["main"],
                   "countType": "imageCountMoreThan",
-                  "countNumber": 5
+                  "countNumber": 25
                 },
                 "action": {
                   "type": "expire"
                 }
               },
               {
-                "rulePriority": 2,
-                "description": "Expire untagged images older than 90 days",
+                "rulePriority": 11,
+                "description": "Keep 25 versions of master tag",
                 "selection": {
-                  "tagStatus": "untagged",
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["master"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 25
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 20,
+                "description": "Expire any images older than 90 days",
+                "selection": {
+                  "tagStatus": "any",
                   "countType": "sinceImagePushed",
                   "countUnit": "days",
                   "countNumber": 90
@@ -141,12 +151,12 @@ jobs:
                 }
               },
               {
-                "rulePriority": 3,
-                "description": "Keep total count to 100 images",
+                "rulePriority": 30,
+                "description": "Keep total count to 1000 images",
                 "selection": {
                   "tagStatus": "any",
                   "countType": "imageCountMoreThan",
-                  "countNumber": 100
+                  "countNumber": 1000
                 },
                 "action": {
                   "type": "expire"


### PR DESCRIPTION
The tagPrefixList works in an unexpected way - the prefixes are matched with AND, not with OR, so an image needs to be tagged with *all* the specified prefixes for the rule to apply. Since we were specifying both `main` and `master` in the same tagPrefixList, no images were being matched.

Rule changes:

- Increase the number of retained images prefixed with `main` or `master` to 25, since we have service-relais which expects to publish at least 18 different images for each branch at the time of this commit.

- Expire any images older than 90 days, not just untagged. Ensures that we don't keep really old branch builds lying around (if your branch hasn't been built and deployed in 3 months then too bad.) `main` and `master` images will be protected by the previous rule.

- Keep the total image count to 1000. The maximum image limit for ECR is now 10k per repository but we should aim not to keep too many unused images lying around. Increasing the limit though because service-relais could have many branch builds of ~20 images each and we
