### PR TITLE
fix(tf-aws): add complete accumulator job

### DIFF
--- a/.github/workflows/tf-aws.yaml
+++ b/.github/workflows/tf-aws.yaml
@@ -243,3 +243,11 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         working-directory: ${{ inputs.path }}
         run: if test -f tfplan; then terraform apply -no-color tfplan; fi
+
+  complete:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [run]
+    steps:
+      - if: ${{ needs.run.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Adds a `complete` job that depends on the `run` matrix job so that we
can add it as a required check in GitHub branch protection.
