### PR TITLE
fix(tf-aws): export boundary_policy_arn with TF_VAR_xxxx

### DIFF
--- a/.github/workflows/tf-aws.yaml
+++ b/.github/workflows/tf-aws.yaml
@@ -136,9 +136,7 @@ jobs:
             }
           }
           EOF
-          cat <<EOF >_workflow.tfvars
-          boundary_policy_arn = "arn:aws:iam::${{ matrix.env.aws_account_id }}:policy/gha/gha_${{ needs.init.outputs.repository }}"
-          EOF
+          echo TF_VAR_boundary_policy_arn="arn:aws:iam::${{ matrix.env.aws_account_id }}:policy/gha/gha_${{ needs.init.outputs.repository }}" >> $GITHUB_ENV
 
           terraform init \
             -backend-config="bucket=tfstate.mgmt.hubs.com" \
@@ -150,9 +148,7 @@ jobs:
 
       - name: plan
         working-directory: ${{ inputs.path }}
-        env:
-          tfvars: vars/${{ matrix.env.name }}.tfvars
-        run: terraform plan -no-color -out=tfplan -var-file="$tfvars" -var-file="_workflow.tfvars"
+        run: terraform plan -no-color -out=tfplan -var-file="vars/${{ matrix.env.name }}.tfvars"
       - name: apply
         if: ${{ github.ref == 'refs/heads/main' }}
         working-directory: ${{ inputs.path }}


### PR DESCRIPTION
Fixes the following warning seen in workflow runs:

The root module does not declare a variable named "boundary_policy_arn" but a
value was found in file "_workflow.tfvars". If you meant to use this value,
add a "variable" block to the configuration.
